### PR TITLE
Include logger role in V4::Client (closes #19)

### DIFF
--- a/lib/WebService/Mattermost/V4/Client.pm
+++ b/lib/WebService/Mattermost/V4/Client.pm
@@ -11,6 +11,7 @@ use Types::Standard qw(ArrayRef Bool InstanceOf Int Maybe Str);
 
 extends 'WebService::Mattermost';
 with    qw(
+    WebService::Mattermost::Role::Logger
     WebService::Mattermost::Role::UserAgent
     Role::EventEmitter
 );

--- a/t/unit/WebService/Mattermost/V4/Client.t
+++ b/t/unit/WebService/Mattermost/V4/Client.t
@@ -20,6 +20,12 @@ describe 'WebService::Mattermost::V4::Client' => sub {
         $vars{app} = WebService::Mattermost::V4::Client->new($vars{init_args});
     };
 
+    describe 'roles' => sub {
+        it 'should include the logger role' => sub {
+            ok $vars{app}->does('WebService::Mattermost::Role::Logger');
+        };
+    };
+
     describe '#websocket_url' => sub {
         context 'with trailing slash' => sub {
             it 'should switch the HTTP API URL for a websocket one' => sub {


### PR DESCRIPTION
# Changelog

## Fixed

* Adds the missing "logger" role to `WebService::Mattermost::V4::Client`. This bug was only present when `debug` was true for this class.