### PR TITLE
Correctly detect and report request errors

### DIFF
--- a/lib/WebService/Mattermost/V4/API/Resource.pm
+++ b/lib/WebService/Mattermost/V4/API/Resource.pm
@@ -148,6 +148,11 @@ sub _call {
         $form_type    => $request->parameters,
     );
 
+    if (my $error = $tx->req->error) {
+        $self->logger->warn('No HTTP code was received from Mattermost. Is your server alive?');
+        $self->logger->warnf('The following may be useful: %s', $error->{message});
+    }
+
     return $self->_as_response($tx->res, $args);
 }
 
@@ -175,14 +180,6 @@ sub _as_response {
 
     if ($args->{view}) {
         $view_name = $args->{view};
-    }
-
-    unless ($res->code) {
-        $self->logger->warn('No HTTP code was received from Mattermost. Is your server alive?');
-
-        if ($res->message) {
-            $self->logger->warnf('The following may be useful: %s', $res->message);
-        }
     }
 
     if ($res->is_error && $self->debug) {


### PR DESCRIPTION
The current check for request errors is incorrect and won't report the actual error message (such as missing SSL dependencies, DNS errors, etc). A request error will be found in the request object, rather than the response object, so it needs to be checked before _as_response which only receives the response object. The request object doesn't have a ->message method, the error message will be found in the structure returned by ->error in this case.

There's also probably no use in proceeding to _as_response as the response will always be empty when this happens, but I didn't change anything around that.