### PR TITLE
Fix construction of related resources (missing "api" attribute)

### DIFF
--- a/lib/WebService/Mattermost/V4/API.pm
+++ b/lib/WebService/Mattermost/V4/API.pm
@@ -61,46 +61,47 @@ has resources              => (is => 'rw', isa => ArrayRef, default => sub { [] 
         add_resource => 'push',
     });
 
-has analytics         => (is => 'ro', isa => InstanceOf[v4 'Analytics'],          lazy => 1, builder => 1);
-has application       => (is => 'ro', isa => InstanceOf[v4 'OAuth::Application'], lazy => 1, builder => 1);
-has audits            => (is => 'ro', isa => InstanceOf[v4 'Audits'],             lazy => 1, builder => 1);
-has bots              => (is => 'ro', isa => InstanceOf[v4 'Bots'],               lazy => 1, builder => 1);
-has brand             => (is => 'ro', isa => InstanceOf[v4 'Brand'],              lazy => 1, builder => 1);
-has cache             => (is => 'ro', isa => InstanceOf[v4 'Cache'],              lazy => 1, builder => 1);
-has channel           => (is => 'ro', isa => InstanceOf[v4 'Channel'],            lazy => 1, builder => 1);
-has channel_member    => (is => 'ro', isa => InstanceOf[v4 'Channel::Member'],    lazy => 1, builder => 1);
-has channels          => (is => 'ro', isa => InstanceOf[v4 'Channels'],           lazy => 1, builder => 1);
-has cluster           => (is => 'ro', isa => InstanceOf[v4 'Cluster'],            lazy => 1, builder => 1);
-has compliance        => (is => 'ro', isa => InstanceOf[v4 'Compliance'],         lazy => 1, builder => 1);
-has compliance_report => (is => 'ro', isa => InstanceOf[v4 'Compliance::Report'], lazy => 1, builder => 1);
-has data_retention    => (is => 'ro', isa => InstanceOf[v4 'DataRetention'],      lazy => 1, builder => 1);
-has database          => (is => 'ro', isa => InstanceOf[v4 'Database'],           lazy => 1, builder => 1);
-has elasticsearch     => (is => 'ro', isa => InstanceOf[v4 'ElasticSearch'],      lazy => 1, builder => 1);
-has email             => (is => 'ro', isa => InstanceOf[v4 'Email'],              lazy => 1, builder => 1);
-has emoji             => (is => 'ro', isa => InstanceOf[v4 'Emoji'],              lazy => 1, builder => 1);
-has file              => (is => 'ro', isa => InstanceOf[v4 'File'],               lazy => 1, builder => 1);
-has files             => (is => 'ro', isa => InstanceOf[v4 'Files'],              lazy => 1, builder => 1);
-has job               => (is => 'ro', isa => InstanceOf[v4 'Job'],                lazy => 1, builder => 1);
-has jobs              => (is => 'ro', isa => InstanceOf[v4 'Jobs'],               lazy => 1, builder => 1);
-has ldap              => (is => 'ro', isa => InstanceOf[v4 'LDAP'],               lazy => 1, builder => 1);
-has logs              => (is => 'ro', isa => InstanceOf[v4 'Logs'],               lazy => 1, builder => 1);
-has oauth             => (is => 'ro', isa => InstanceOf[v4 'OAuth'],              lazy => 1, builder => 1);
-has plugin            => (is => 'ro', isa => InstanceOf[v4 'Plugin'],             lazy => 1, builder => 1);
-has plugins           => (is => 'ro', isa => InstanceOf[v4 'Plugins'],            lazy => 1, builder => 1);
-has post              => (is => 'ro', isa => InstanceOf[v4 'Post'],               lazy => 1, builder => 1);
-has posts             => (is => 'ro', isa => InstanceOf[v4 'Posts'],              lazy => 1, builder => 1);
-has reactions         => (is => 'ro', isa => InstanceOf[v4 'Reactions'],          lazy => 1, builder => 1);
-has roles             => (is => 'ro', isa => InstanceOf[v4 'Roles'],              lazy => 1, builder => 1);
-has s3                => (is => 'ro', isa => InstanceOf[v4 'S3'],                 lazy => 1, builder => 1);
-has saml              => (is => 'ro', isa => InstanceOf[v4 'SAML'],               lazy => 1, builder => 1);
-has schemes           => (is => 'ro', isa => InstanceOf[v4 'Schemes'],            lazy => 1, builder => 1);
-has system            => (is => 'ro', isa => InstanceOf[v4 'System'],             lazy => 1, builder => 1);
-has team              => (is => 'ro', isa => InstanceOf[v4 'Team'],               lazy => 1, builder => 1);
-has teams             => (is => 'ro', isa => InstanceOf[v4 'Teams'],              lazy => 1, builder => 1);
-has user              => (is => 'ro', isa => InstanceOf[v4 'User'],               lazy => 1, builder => 1);
-has users             => (is => 'ro', isa => InstanceOf[v4 'Users'],              lazy => 1, builder => 1);
-has webhooks          => (is => 'ro', isa => InstanceOf[v4 'Webhook'],            lazy => 1, builder => 1);
-has webrtc            => (is => 'ro', isa => InstanceOf[v4 'WebRTC'],             lazy => 1, builder => 1);
+has analytics         => (is => 'lazy', isa => InstanceOf[v4 'Analytics']);
+has application       => (is => 'lazy', isa => InstanceOf[v4 'OAuth::Application']);
+has audits            => (is => 'lazy', isa => InstanceOf[v4 'Audits']);
+has bots              => (is => 'lazy', isa => InstanceOf[v4 'Bots']);
+has brand             => (is => 'lazy', isa => InstanceOf[v4 'Brand']);
+has cache             => (is => 'lazy', isa => InstanceOf[v4 'Cache']);
+has channel           => (is => 'lazy', isa => InstanceOf[v4 'Channel']);
+has channel_member    => (is => 'lazy', isa => InstanceOf[v4 'Channel::Member']);
+has channels          => (is => 'lazy', isa => InstanceOf[v4 'Channels']);
+has cluster           => (is => 'lazy', isa => InstanceOf[v4 'Cluster']);
+has compliance        => (is => 'lazy', isa => InstanceOf[v4 'Compliance']);
+has compliance_report => (is => 'lazy', isa => InstanceOf[v4 'Compliance::Report']);
+has data_retention    => (is => 'lazy', isa => InstanceOf[v4 'DataRetention']);
+has database          => (is => 'lazy', isa => InstanceOf[v4 'Database']);
+has elasticsearch     => (is => 'lazy', isa => InstanceOf[v4 'ElasticSearch']);
+has email             => (is => 'lazy', isa => InstanceOf[v4 'Email']);
+has emoji             => (is => 'lazy', isa => InstanceOf[v4 'Emoji']);
+has file              => (is => 'lazy', isa => InstanceOf[v4 'File']);
+has files             => (is => 'lazy', isa => InstanceOf[v4 'Files']);
+has job               => (is => 'lazy', isa => InstanceOf[v4 'Job']);
+has jobs              => (is => 'lazy', isa => InstanceOf[v4 'Jobs']);
+has ldap              => (is => 'lazy', isa => InstanceOf[v4 'LDAP']);
+has logs              => (is => 'lazy', isa => InstanceOf[v4 'Logs']);
+has oauth             => (is => 'lazy', isa => InstanceOf[v4 'OAuth']);
+has plugin            => (is => 'lazy', isa => InstanceOf[v4 'Plugin']);
+has plugins           => (is => 'lazy', isa => InstanceOf[v4 'Plugins']);
+has post              => (is => 'lazy', isa => InstanceOf[v4 'Post']);
+has posts             => (is => 'lazy', isa => InstanceOf[v4 'Posts']);
+has reactions         => (is => 'lazy', isa => InstanceOf[v4 'Reactions']);
+has roles             => (is => 'lazy', isa => InstanceOf[v4 'Roles']);
+has s3                => (is => 'lazy', isa => InstanceOf[v4 'S3']);
+has saml              => (is => 'lazy', isa => InstanceOf[v4 'SAML']);
+has schemes           => (is => 'lazy', isa => InstanceOf[v4 'Schemes']);
+has system            => (is => 'lazy', isa => InstanceOf[v4 'System']);
+has team              => (is => 'lazy', isa => InstanceOf[v4 'Team']);
+has team_channels     => (is => 'lazy', isa => InstanceOf[v4 'Team::Channels']);
+has teams             => (is => 'lazy', isa => InstanceOf[v4 'Teams']);
+has user              => (is => 'lazy', isa => InstanceOf[v4 'User']);
+has users             => (is => 'lazy', isa => InstanceOf[v4 'Users']);
+has webhooks          => (is => 'lazy', isa => InstanceOf[v4 'Webhook']);
+has webrtc            => (is => 'lazy', isa => InstanceOf[v4 'WebRTC']);
 
 ################################################################################
 
@@ -183,6 +184,7 @@ sub _build_schemes           { shift->_new_resource('Schemes')                  
 sub _build_system            { shift->_new_resource('System')                           }
 sub _build_team              { shift->_new_resource('Team', 'teams')                    }
 sub _build_teams             { shift->_new_resource('Teams')                            }
+sub _build_team_channels     { shift->_new_resource('Team::Channels', 'team')  }
 sub _build_user              { shift->_new_resource('User', 'users')                    }
 sub _build_users             { shift->_new_resource('Users')                            }
 sub _build_webhooks          { shift->_new_resource('Webhook', 'hooks')                 }

--- a/lib/WebService/Mattermost/V4/API/Object.pm
+++ b/lib/WebService/Mattermost/V4/API/Object.pm
@@ -8,7 +8,10 @@ use Types::Standard qw(HashRef InstanceOf Str);
 
 use WebService::Mattermost::V4::API;
 
-with 'WebService::Mattermost::Role::Returns';
+with qw(
+    WebService::Mattermost::Role::Returns
+    WebService::Mattermost::V4::API::Role::NewRelatedResource
+);
 
 ################################################################################
 

--- a/lib/WebService/Mattermost/V4/API/Object/Team.pm
+++ b/lib/WebService/Mattermost/V4/API/Object/Team.pm
@@ -3,7 +3,9 @@ package WebService::Mattermost::V4::API::Object::Team;
 # ABSTRACT: A team item.
 
 use Moo;
-use Types::Standard qw(Bool Str);
+use Types::Standard qw(Bool InstanceOf Str);
+
+use WebService::Mattermost::Helper::Alias 'v4';
 
 extends 'WebService::Mattermost::V4::API::Object';
 with    qw(
@@ -16,12 +18,13 @@ with    qw(
 
 ################################################################################
 
-has company_name   => (is => 'ro', isa => Str,  lazy => 1, builder => 1);
-has display_name   => (is => 'ro', isa => Str,  lazy => 1, builder => 1);
-has email          => (is => 'ro', isa => Str,  lazy => 1, builder => 1);
-has invite_id      => (is => 'ro', isa => Str,  lazy => 1, builder => 1);
-has is_invite_only => (is => 'ro', isa => Bool, lazy => 1, builder => 1);
-has open_invite    => (is => 'ro', isa => Bool, lazy => 1, builder => 1);
+has channels       => (is => 'lazy', isa => InstanceOf[v4 'Team::Channels']);
+has company_name   => (is => 'lazy', isa => Str);
+has display_name   => (is => 'lazy', isa => Str);
+has email          => (is => 'lazy', isa => Str);
+has invite_id      => (is => 'lazy', isa => Str);
+has is_invite_only => (is => 'lazy', isa => Bool);
+has open_invite    => (is => 'lazy', isa => Bool);
 
 ################################################################################
 
@@ -32,6 +35,7 @@ sub BUILD {
     $self->set_available_api_methods([ qw(
         add_member
         add_members
+        channels.public
         delete
         get_icon
         invite_by_emails
@@ -50,6 +54,16 @@ sub BUILD {
 }
 
 ################################################################################
+
+sub _build_channels {
+    my $self = shift;
+
+    my $team_channels = $self->new_related_resource('teams', 'Team::Channels');
+
+    $team_channels->id($self->id);
+
+    return $team_channels;
+}
 
 sub _build_company_name   { shift->raw_data->{company_name}        }
 sub _build_display_name   { shift->raw_data->{display_name}        }

--- a/lib/WebService/Mattermost/V4/API/Resource.pm
+++ b/lib/WebService/Mattermost/V4/API/Resource.pm
@@ -4,9 +4,9 @@ package WebService::Mattermost::V4::API::Resource;
 
 use List::MoreUtils 'all';
 use Moo;
-use Types::Standard qw(Bool HashRef Object Str);
+use Types::Standard qw(Bool HashRef Maybe Object Str);
 
-use WebService::Mattermost::Helper::Alias qw(v4 view);
+use WebService::Mattermost::Helper::Alias 'view';
 use WebService::Mattermost::V4::API::Object::Channel;
 use WebService::Mattermost::V4::API::Object::Icon;
 use WebService::Mattermost::V4::API::Object::Status;
@@ -24,6 +24,7 @@ with qw(
     WebService::Mattermost::Role::Returns
     WebService::Mattermost::Role::UserAgent
     WebService::Mattermost::V4::API::Role::RequireID
+    WebService::Mattermost::V4::API::Role::NewRelatedResource
 );
 
 ################################################################################
@@ -39,6 +40,8 @@ has headers => (is => 'ro', isa => HashRef, default => sub { {} });
 has POST    => (is => 'ro', isa => Str,     default => 'POST');
 has PUT     => (is => 'ro', isa => Str,     default => 'PUT');
 has debug   => (is => 'ro', isa => Bool,    default => 0);
+
+has id => (is => 'rw', isa => Maybe[Str]);
 
 ################################################################################
 
@@ -225,18 +228,6 @@ sub _validate {
         missing => \@missing,
         error   => sprintf('Required parameters missing: %s', join(', ', @missing)),
     };
-}
-
-sub _new_related_resource {
-    my $self     = shift;
-    my $base     = shift;
-    my $resource = shift;
-
-    return v4($resource)->new({
-        auth_token => $self->auth_token,
-        base_url   => $self->base_url,
-        resource   => $base,
-    });
 }
 
 ################################################################################

--- a/lib/WebService/Mattermost/V4/API/Resource/SAML.pm
+++ b/lib/WebService/Mattermost/V4/API/Resource/SAML.pm
@@ -27,7 +27,7 @@ sub metadata {
 sub _build_certificate {
     my $self = shift;
 
-    return $self->_new_related_resource('saml', 'SAML::Certificate');
+    return $self->new_related_resource('saml', 'SAML::Certificate');
 }
 
 ################################################################################

--- a/lib/WebService/Mattermost/V4/API/Resource/Team.pm
+++ b/lib/WebService/Mattermost/V4/API/Resource/Team.pm
@@ -16,7 +16,7 @@ with    qw(
 
 ################################################################################
 
-has channels => (is => 'ro', isa => InstanceOf[v4 'Team::Channels'], lazy => 1, builder => 1);
+has channels => (is => 'lazy', isa => InstanceOf[v4 'Team::Channels']);
 
 ################################################################################
 
@@ -357,7 +357,7 @@ sub search_posts {
 sub _build_channels {
     my $self = shift;
 
-    return $self->_new_related_resource('teams', 'Team::Channels');
+    return $self->new_related_resource('teams', 'Team::Channels');
 }
 
 ################################################################################

--- a/lib/WebService/Mattermost/V4/API/Resource/Team/Channels.pm
+++ b/lib/WebService/Mattermost/V4/API/Resource/Team/Channels.pm
@@ -35,7 +35,7 @@ sub by_ids {
 
 sub public {
     my $self    = shift;
-    my $team_id = shift;
+    my $team_id = shift || $self->id;
     my $args    = shift;
 
     return $self->_get({

--- a/lib/WebService/Mattermost/V4/API/Resource/Webhook.pm
+++ b/lib/WebService/Mattermost/V4/API/Resource/Webhook.pm
@@ -21,13 +21,13 @@ has outgoing => (is => 'ro', isa => InstanceOf[v4 'Webhook::Incoming'], lazy => 
 sub _build_incoming {
     my $self = shift;
 
-    return $self->_new_related_resource('webhooks', 'Webhook::Incoming');
+    return $self->new_related_resource('webhooks', 'Webhook::Incoming');
 }
 
 sub _build_outgoing {
     my $self = shift;
 
-    return $self->_new_related_resource('webhooks', 'Webhook::Outgoing');
+    return $self->new_related_resource('webhooks', 'Webhook::Outgoing');
 }
 
 ################################################################################

--- a/lib/WebService/Mattermost/V4/API/Role/NewRelatedResource.pm
+++ b/lib/WebService/Mattermost/V4/API/Role/NewRelatedResource.pm
@@ -1,0 +1,24 @@
+package WebService::Mattermost::V4::API::Role::NewRelatedResource;
+
+use Moo::Role;
+
+use WebService::Mattermost::Helper::Alias 'v4';
+
+################################################################################
+
+sub new_related_resource {
+    my $self     = shift;
+    my $base     = shift;
+    my $resource = shift;
+
+    return v4($resource)->new({
+        api        => $self->api,
+        auth_token => $self->auth_token,
+        base_url   => $self->base_url,
+        resource   => $base,
+    });
+}
+
+################################################################################
+
+1;

--- a/lib/WebService/Mattermost/V4/API/Role/RequireID.pm
+++ b/lib/WebService/Mattermost/V4/API/Role/RequireID.pm
@@ -16,7 +16,7 @@ has id_validation_regexp => (is => 'ro', isa => RegexpRef, default => sub { qr{(
 sub validate_id {
     my $self = shift;
     my $next = shift;
-    my $id   = shift;
+    my $id   = shift || $self->id;
 
     if ($self->validate_id_no_next($id)) {
         return $self->$next($id, @_);
@@ -27,7 +27,7 @@ sub validate_id {
 
 sub validate_id_no_next {
     my $self = shift;
-    my $id   = shift;
+    my $id   = shift || $self->id;
 
     return ($id && $id =~ $self->id_validation_regexp) ? 1 : 0;
 }

--- a/t/unit/WebService/Mattermost/V4/API/Object/Team.t
+++ b/t/unit/WebService/Mattermost/V4/API/Object/Team.t
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl -T
+
+use Test::Spec;
+
+require 'test_helper.pl';
+
+describe 'WebService::Mattermost::V4::API::Object::Team' => sub {
+    share my %vars;
+
+    describe '#channels' => sub {
+        before all => sub {
+            $vars{team} = WebService::Mattermost::V4::API::Object::Team->new({
+                auth_token => AUTH_TOKEN(),
+                base_url   => BASE_URL(),
+                raw_data   => { id => 'my-test-team-id' },
+            });
+        };
+
+        it 'is an instance of WebService::Mattermost::V4::API::Resource::Team::Channels' => sub {
+            isa_ok $vars{team}->channels, 'WebService::Mattermost::V4::API::Resource::Team::Channels';
+        };
+
+        it 'was built with the team ID' => sub {
+            is $vars{team}->channels->id, 'my-test-team-id';
+        };
+
+        it 'has the expected available methods' => sub {
+            my $ok = 1;
+
+            foreach my $method (qw(public by_ids deleted autocomplete search by_name_and_team_name by_name)) {
+                $ok = 0 unless $vars{team}->channels->can($method);
+            }
+
+            ok $ok;
+        };
+    };
+};
+
+runtests unless caller;

--- a/t/unit/WebService/Mattermost/V4/API/Resource/Team/Channels.t
+++ b/t/unit/WebService/Mattermost/V4/API/Resource/Team/Channels.t
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl -T
+
+use Test::Spec;
+
+require 'test_helper.pl';
+
+describe 'WebService::Mattermost::V4::API::Resource::Team::Channels' => sub {
+    share my %vars;
+
+    describe '#public' => sub {
+        context 'with an "id" attribute set' => sub {
+            before all => sub {
+                $vars{get_request} = {
+                    class_method_closure => sub {
+                        my $team_channels = shift->api->team_channels;
+
+                        $team_channels->id('my-team-id-attribute');
+
+                        return $team_channels->public;
+                    },
+                    url                  => '/team/my-team-id-attribute/channels',
+                    resource             => 'team_channels',
+                };
+            };
+
+            it_should_behave_like 'a GET API endpoint';
+        };
+
+        context 'with an "id" variable passed' => sub {
+            before all => sub {
+                $vars{get_request} = {
+                    class_method_closure => sub { shift->api->team_channels->public('my-team-id-variable') },
+                    url                  => '/team/my-team-id-variable/channels',
+                    resource             => 'team_channels',
+                };
+            };
+
+            it_should_behave_like 'a GET API endpoint';
+        };
+    };
+};
+
+runtests unless caller;


### PR DESCRIPTION
# Changelog

## Added

* `channels` accessor to the `Team` view. This allows for calling for a `Team` object's channels.

## Changed

* Style of Moo "lazy builders" (switched `is => 'ro', ..., lazy => 1, builder => 1` for `is => 'lazy'` for shorter lines).

## Fixed

* Missing "api" attribute for resources built from other resources (e.g. `Team::Channels`, `Channel::Members`).